### PR TITLE
Add matplotlib to requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,10 @@ requirements:
 test:
   imports:
     - PyMca5
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: http://pymca.sourceforge.net

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3961d8161b5fbb50f06fc06df8b13b33470888be574127dd99e730d96272d28d
 
 build:
-  number: 0
+  number: 1
   script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv '
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   host:
     - fisx >=1.1.6
     - h5py
-    - matplotlib > 1.0
+    - matplotlib-base >1.0
     - numpy
     - pip
     - python
@@ -27,7 +27,7 @@ requirements:
   run:
     - fisx >=1.1.6
     - h5py
-    - matplotlib > 1.0
+    - matplotlib-base >1.0
     - numpy
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   host:
     - fisx >=1.1.6
     - h5py
+    - matplotlib > 1.0
     - numpy
     - pip
     - python
@@ -26,6 +27,7 @@ requirements:
   run:
     - fisx >=1.1.6
     - h5py
+    - matplotlib > 1.0
     - numpy
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
   host:
     - fisx >=1.1.6
     - h5py
-    - matplotlib-base >1.0
     - numpy
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - fisx >=1.1.6
     - h5py
     - matplotlib-base >1.0
-    - numpy
+    - {{ pin_compatible('numpy') }}
     - python
 
 test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
`matplotlib` is listed in the `install_requires` section of `setup.py`:
https://github.com/vasole/pymca/blob/674dee7be0c04b10c3a399a5310e2c2dfd205488/setup.py#L870

Not including `matplotlib` in the conda-forge package may break downstream packages that depend on `PyMca5` but don't explicitly include `matplotlib`.